### PR TITLE
fix(error): ensure that 500 is returned when present

### DIFF
--- a/src/fetchers.js
+++ b/src/fetchers.js
@@ -20,13 +20,15 @@ function defaultResolver(res) {
   if (res && res.statusCode >= 400) {
     const { params } = res.actionOptions;
     const rp = `${params.owner}/${params.repo}/${params.ref}${params.path}`;
-    return Promise.reject(new Error(`Error invoking ${res.actionOptions.name}(${rp}): ${res.statusCode}`));
+    const error = new Error(`Error invoking ${res.actionOptions.name}(${rp}): ${res.statusCode}`);
+    error.statusCode = res.statusCode;
+    return Promise.reject(error);
   }
   return Promise.resolve(res);
 }
 
 /**
- * Resolver used for error pages. Resolves with a 404 if the action responed with a 200.
+ * Resolver used for error pages. Resolves with a 404 if the action responded with a 200.
  * @param res action response
  * @returns {Promise<any>}
  */
@@ -35,9 +37,7 @@ function errorPageResolver(res) {
     res.statusCode = 404;
     return Promise.resolve(res);
   }
-  const { params } = res.actionOptions;
-  const rp = `${params.owner}/${params.repo}/${params.ref}${params.path}`;
-  return Promise.reject(new Error(`Error invoking ${res.actionOptions.name}(${rp}): ${res.statusCode}`));
+  return defaultResolver(res);
 }
 
 /**
@@ -145,7 +145,6 @@ function fetchers(params = {}) {
       resolve: defaultResolver,
       name: staticaction,
       blocking: true,
-      result: true,
       params: {
         path: info.path,
         entry: info.path,
@@ -165,7 +164,6 @@ function fetchers(params = {}) {
       resolve: defaultResolver,
       name: actionname,
       blocking: true,
-      result: true,
       params: {
         path: `${info.relPath}.md`,
         ...contentOpts,
@@ -179,7 +177,6 @@ function fetchers(params = {}) {
       resolve: defaultResolver,
       name: staticaction,
       blocking: true,
-      result: true,
       params: {
         path: info.path,
         entry: info.path,
@@ -196,7 +193,6 @@ function fetchers(params = {}) {
       resolve: errorPageResolver,
       name: staticaction,
       blocking: true,
-      result: true,
       params: {
         path: '/404.html',
         entry: '/404.html',
@@ -211,7 +207,6 @@ function fetchers(params = {}) {
       resolve: errorPageResolver,
       name: staticaction,
       blocking: true,
-      result: true,
       params: {
         path: '/404.html',
         entry: '/404.html',


### PR DESCRIPTION
partial fix for #28. but when 404.html is present in the repository, the error would still be masked.

I also added some better log output:

```
2019-07-04T08:02:43.859Z       stdout: INFO  - [3] 07b0d8e5fe974c57b0d8e5fe972c5771 404
2019-07-04T08:02:43.871Z       stdout: INFO  - [0] b751db0f920e479f91db0f920e379fc4 404
2019-07-04T08:02:43.888Z       stdout: INFO  - [4] 5dc264f5a64044bf8264f5a64094bf8a 404
2019-07-04T08:02:43.908Z       stdout: INFO  - [2] 26c488cfe6ae44db8488cfe6ae74dbcc 404
2019-07-04T08:02:43.981Z       stdout: INFO  - [1] e134bba6546540b5b4bba6546520b584 500 TypeError: Cannot set property 'authorization' of undefined
2019-07-04T08:02:43.981Z       stdout: ERROR - no valid response could be fetched
2019-07-04T08:02:43.981Z       stdout: ERROR - Error invoking github-com--tripodsan--hlxtest--master-dirty/hlx--static(tripodsan/hlxtest/master/index.html): 404
2019-07-04T08:02:43.981Z       stdout: ERROR - Error invoking github-com--tripodsan--hlxtest--master-dirty/html(tripodsan/hlxtest/master/index.md): 500
2019-07-04T08:02:43.981Z       stdout: ERROR - Error invoking github-com--tripodsan--hlxtest--master-dirty/hlx--static(tripodsan/hlxtest/master/index.html): 404
2019-07-04T08:02:43.982Z       stdout: ERROR - Error invoking github-com--tripodsan--hlxtest--master-dirty/hlx--static(tripodsan/hlxtest/master/404.html): 404
2019-07-04T08:02:43.982Z       stdout: ERROR - Error invoking github-com--tripodsan--hlxtest--master-dirty/hlx--static(tripodsan/hlxtest/master/404.html): 404
```
